### PR TITLE
Fix object space

### DIFF
--- a/lib/pickle/adapters/mongoid.rb
+++ b/lib/pickle/adapters/mongoid.rb
@@ -17,7 +17,7 @@ module Mongoid
 
       # get a list of column names for a given class
       def self.column_names(klass)
-        klass.try[:fields].try[:keys] || []
+        klass.try(:fields).try(:keys) || []
       end
 
       # Get an instance by id of the model


### PR DESCRIPTION
When using super-huge GC limits (for speeding up tests), occasionally we'll see abandoned Mongoid::Document classes appear in the ObjectSpace. This patch should fix that.
