### PR TITLE
allow escaped quotation marks in fields

### DIFF
--- a/features/pickle/create_from_active_record.feature
+++ b/features/pickle/create_from_active_record.feature
@@ -16,6 +16,10 @@ Feature: I can easily create models from my blueprints
     Then a user should exist with name: "Fred"
     And a user should exist with status: "crayzee"
     But a user should not exist with name: "Wilma"
+
+  Scenario: I create a user with quotes in its status, and see if it looks right
+    Given a user exists with name: "Fred", status: "a little \"off\""
+    Then a user should exist with status: "a little \"off\""
   
   Scenario: I create a user via a mapping
     Given I exist with status: "pwned", name: "fred"
@@ -43,19 +47,22 @@ Feature: I can easily create models from my blueprints
     
   Scenario: create and find using tables
     Given the following users exist:
-      | name  | status                   |
-      | Jim   | married                  |
-      | Ethel | in a relationship with x |
+      | name   | status                    |
+      | Jim    | married                   |
+      | Ethel  | in a relationship with x  |
+      | Garvin | in an "open" relationship |
     Then the following users should exist:
-      | name  |
-      | Jim   |
-      | Ethel |
+      | name   |
+      | Jim    |
+      | Ethel  |
+      | Garvin |
     And the following users should exist:
-      | status                   |
-      | married                  |
-      | in a relationship with x |
-    And the 1st user should be the 3rd user
-    And the 2nd user should be the last user
+      | status                    |
+      | married                   |
+      | in a relationship with x  |
+      | in an "open" relationship |
+    And the 1st user should be the 4th user
+    And the 3rd user should be the last user
     
     Scenario: create and find using tables with referencable names
       Given the following users exist:

--- a/lib/pickle/parser/matchers.rb
+++ b/lib/pickle/parser/matchers.rb
@@ -14,7 +14,7 @@ module Pickle
       end
   
       def match_quoted
-        '(?:[^\\"]|\\.)*'
+        '(?:\\\\"|[^\\"]|\\.)*'
       end
   
       def match_label

--- a/spec/pickle/parser/matchers_spec.rb
+++ b/spec/pickle/parser/matchers_spec.rb
@@ -41,7 +41,7 @@ describe Pickle::Parser::Matchers do
       atom_should_match     :match_label, [': "gday"', ': "gday mate"']
       atom_should_not_match :match_label, [': "gday""', ': gday']
   
-      atom_should_match     :match_field, ['foo: "this is the life"', 'bar_man: "and so is this"', 'boolean: false', 'boolean: true', 'numeric: 10', 'numeric: 12.5', 'numeric: +10', 'numeric: +12.5', 'numeric: -10', 'numeric: -12.5', 'nil_field: nil']
+      atom_should_match     :match_field, ['foo: "this is the life"', 'bar_man: "and so is this"', 'quoted_baz: "words \"in quotes\""', 'boolean: false', 'boolean: true', 'numeric: 10', 'numeric: 12.5', 'numeric: +10', 'numeric: +12.5', 'numeric: -10', 'numeric: -12.5', 'nil_field: nil']
       atom_should_not_match :match_field, ['foo bar: "this aint workin"', 'not_numeric: --10', 'not_numeric: -ten']
   
       atom_should_match     :match_fields, ['foo: "bar"', 'foo: "bar", baz: "bah"']

--- a/spec/pickle/parser_spec.rb
+++ b/spec/pickle/parser_spec.rb
@@ -53,6 +53,10 @@ describe Pickle::Parser do
       it '(\'foo: "bar"\') should == { "foo" => "bar"}' do
         @parser.parse_fields('foo: "bar"').should == { "foo" => "bar"}
       end
+
+      it '(\'foo: "something \"quoted\""\') should == { "foo" => "bar"}' do
+        @parser.parse_fields('foo: "something \"quoted\""').should == { "foo" => 'something "quoted"' }
+      end
     
       it '("bool: true") should == { "bool" => true}' do
         @parser.parse_fields('bool: true').should == {"bool" => true}
@@ -70,8 +74,8 @@ describe Pickle::Parser do
         @parser.parse_fields('float: 10.1').should == {"float" => 10.1}
       end
 
-      it '(\'foo: "bar", bar_man: "wonga wonga", gump: 123\') should == {"foo" => "bar", "bar_man" => "wonga wonga", "gump" => 123}' do
-        @parser.parse_fields('foo: "bar", bar_man: "wonga wonga", gump: 123').should == {"foo" => "bar", "bar_man" => "wonga wonga", "gump" => 123}
+      it '(\'foo: "bar", bar_man: "wonga wonga", baz_woman: "one \"two\" three", gump: 123\') should == {"foo" => "bar", "bar_man" => "wonga wonga", "gump" => 123}' do
+        @parser.parse_fields('foo: "bar", bar_man: "wonga wonga", baz_woman: "one \"two\" three", gump: 123').should == {"foo" => "bar", "bar_man" => "wonga wonga", "baz_woman" => "one \"two\" three", "gump" => 123}
       end
     end
   


### PR DESCRIPTION
So `parse_fields %q(foo: bar, description: "may contain \"quotation marks\"")` would be:
    {
      "foo" => "bar",
      "description" => "may contain \"quotation marks\""
    }
