### PR TITLE
Find Mongoid associations

### DIFF
--- a/spec/pickle/session_spec.rb
+++ b/spec/pickle/session_spec.rb
@@ -186,6 +186,7 @@ describe Pickle::Session do
   describe '#find_model' do
     before do
       Pickle::Adapter.stub!(:find_first_model).with(user_class, anything).and_return(user)
+      Pickle::Adapter.stub!(:column_names).with(user_class).and_return(['username', 'email'])
     end
 
     it "should call user_class.find :first, :conditions => {<fields>}" do
@@ -264,6 +265,7 @@ describe Pickle::Session do
   describe "#find_models" do
     before do
       Pickle::Adapter.stub!(:find_all_models).with(user_class, anything).and_return([user])
+      Pickle::Adapter.stub!(:column_names).with(user_class).and_return(['username', 'email'])
     end
 
     it "should call User.find :all, :conditions => {'hair' => 'pink'}" do


### PR DESCRIPTION
As noted in the extended commit message, there was previously asymmetry between creating and finding models when using Mongoid:

Given a Post model that belongs to a User, a Given step like this would work:

```
Given the following posts exist:
  | title | user        |
  | foo   | user: "bob" |
```

but a similar Then step would not:

```
Then the following posts should exist:
  | title | user        |
  | foo   | user: "bob" |
```

The functionality of loading associations in `convert_models_to_attributes` doesn't really seem to be covered at all in the 0.4.x specs -- sorry for copping out and not adding some to cover it! It seems like something that would be best handled for various adapters with integration tests, and upon thinking this I saw your 0.5-unstable branch where it looks like Cucumber steps may be in the works for just this sort of thing. If I have a chance I'll have a further look at that branch, and take a stab at verifying this if it's not covered already.
