### PR TITLE
Email step name fix

### DIFF
--- a/features/email/email.feature
+++ b/features/email/email.feature
@@ -42,7 +42,7 @@ Feature: I can test emails are sent
   	Given a user exists with name: "Fred", email: "fred@gmail.com"
   	And an email with a link "example page" to the user's page is delivered to fred@gmail.com
     Then 1 email should be delivered to the user
-		And I click the first link in the email
+		And I follow the first link in the email
 		Then I should be at the user's page
 
   Scenario: Following a link in an email by url

--- a/rails_generators/pickle/templates/email_steps.rb
+++ b/rails_generators/pickle/templates/email_steps.rb
@@ -22,7 +22,7 @@ When(/^(?:I|they) follow "([^"]*?)" in #{capture_email}$/) do |link, email_ref|
   visit_in_email(email(email_ref), link)
 end
 
-When(/^(?:I|they) click the first link in #{capture_email}$/) do |email_ref|
+When(/^(?:I|they) follow the first link in #{capture_email}$/) do |email_ref|
   click_first_link_in_email(email(email_ref))
 end
 


### PR DESCRIPTION
I found a inconsistency between the documentation (README) and a email step name, I fixed this according the documentation.

In the documentation:
    When steps
    When [I|they] follow [text_or_regex|the first link] the email, e.g.

```
    When I follow the first link in the email
    When I follow "http://example.com/pickle" in the email
    When I follow "some link text" in the email
```

And the step is:
    When(/^(?:I|they) follow "([^"]*?)" in #{capture_email}$/) do |link, email_ref|
        visit_in_email(email(email_ref), link)
    end

```
When(/^(?:I|they) click the first link in #{capture_email}$/) do |email_ref|
    click_first_link_in_email(email(email_ref))
end
```

Thanks for the awesome Pickle gem.
Ancor Cruz
