### PR TITLE
multipart emails and html body

### DIFF
--- a/lib/pickle/email.rb
+++ b/lib/pickle/email.rb
@@ -20,12 +20,13 @@ module Pickle
     end
 
     def visit_in_email(email, link_text)
-      visit(parse_email_for_link(email, link_text))
+      link = parse_email_for_link(email, link_text)
+      visit URI.parse(link).path
     end
 
     def click_first_link_in_email(email)
       link = links_in_email(email).first
-      visit link
+      visit URI.parse(link).path
     end
 
   protected
@@ -64,13 +65,23 @@ module Pickle
 
     # e.g. Click here in  <a href="http://confirm">Click here</a>
     def parse_email_for_anchor_text_link(email, link_text)
-      if match_data = email.body.match(%r{<a[^>]*href=['"]?([^'"]*)['"]?[^>]*?>[^<]*?#{link_text}[^<]*?</a>})
+      if email.multipart?
+        body = email.html_part.body
+      else
+        body = email.body
+      end
+      if match_data = body.match(%r{<a[^>]*href=['"]?([^'"]*)['"]?[^>]*?>[^<]*?#{link_text}[^<]*?</a>})
         match_data[1]
       end
     end
 
     def links_in_email(email, protos=['http', 'https'])
-      URI.extract(email.body.to_s, protos)
+      if email.multipart?
+        body = email.html_part.body
+      else
+        body = email.body
+      end
+      URI.extract(body.to_s, protos)
     end
 
   end


### PR DESCRIPTION
Hey Ian,

this commit includes how i'm checking for the html body part of multipart email.

Also, have a look at this commit which adds steps which explictly name the "html" and "text" parts of the the mail...  https://github.com/bmabey/email-spec/commit/e5610dfef61f5dc8fb62418f9468c0dbb349ceee   
