### PR TITLE
Update 'show me the email' to use current Launchy API (using launchy-2.0.5)

### DIFF
--- a/lib/pickle/email.rb
+++ b/lib/pickle/email.rb
@@ -31,7 +31,7 @@ module Pickle
   protected
     def open_in_browser(path) # :nodoc
       require "launchy"
-      Launchy::Browser.run(path)
+      Launchy.open(path)
     rescue LoadError
       warn "Sorry, you need to install launchy to open emails: `gem install launchy`"
     end


### PR DESCRIPTION
Refers this deprecation warning:

WARNING: You made a call to a deprecated Launchy API. This call should be changed to 'Launchy.open( uri )'
WARNING: I think I was able to find the location that needs to be fixed. Please go look at:
WARNING: 
WARNING: /Library/Ruby/Gems/1.8/gems/pickle-0.4.8/lib/pickle/email.rb:34:in `open_in_browser'
WARNING:     def open_in_browser(path) # :nodoc
WARNING:       require "launchy"
WARNING:       Launchy::Browser.run(path)
WARNING:     rescue LoadError
WARNING:       warn "Sorry, you need to install launchy to open emails:`gem install launchy`"
WARNING: 
WARNING: If this is not the case, please file a bug. Please file a bug at https://github.com/copiousfreetime/launchy/issues/new
