### PR TITLE
require "activerecord" is deprecated in favor of require "active_record", not vice-versa.

### DIFF
--- a/lib/pickle/adapters/active_record.rb
+++ b/lib/pickle/adapters/active_record.rb
@@ -1,7 +1,7 @@
 begin
-  require 'activerecord'
-rescue LoadError
   require 'active_record'
+rescue LoadError
+  require 'activerecord'
 end
 
 class ActiveRecord::Base


### PR DESCRIPTION
Fixes 'require "activerecord" is deprecated and will be removed in Rails 3. Use require "active_record" instead.'
deprecation warning in Rails 2.3.x apps.
