### PR TITLE
Changed find_first_model to cope with Mongoid 3.0.0

### DIFF
--- a/lib/pickle/adapters/mongoid.rb
+++ b/lib/pickle/adapters/mongoid.rb
@@ -27,7 +27,7 @@ module Mongoid
 
       # Find the first instance matching conditions
       def self.find_first_model(klass, conditions)
-        klass.first
+        klass.where(conditions).first
       end
 
       # Find all models matching conditions


### PR DESCRIPTION
Klass.first(conditions) no longer works in Mongoid 3 (it breaks with an ArgumentError).

Updated the method to stop it raising errors. (It should still work in previous versions too).
