### PR TITLE
Use unscoped Rails 3 finders in ActiveRecord adapter

### DIFF
--- a/lib/pickle/adapters/active_record.rb
+++ b/lib/pickle/adapters/active_record.rb
@@ -31,27 +31,27 @@ class ActiveRecord::Base
 
     # get a list of column names for a given class
     def self.column_names(klass)
-      klass.column_names
+      klass.unscoped { klass.column_names }
     end
 
     # Get an instance by id of the model
     def self.get_model(klass, id)
-      klass.find(id)
+      klass.unscoped { klass.find(id) }
     end
 
     # Find the first instance matching conditions
     def self.find_first_model(klass, conditions)
-      klass.find(:first, :conditions => conditions)
+      klass.unscoped { klass.where(conditions).first }
     end
 
     # Find all models matching conditions
     def self.find_all_models(klass, conditions)
-      klass.find(:all, :conditions => conditions)
+      klass.unscoped { klass.where(conditions) }
     end
-    
+
     # Create a model using attributes
     def self.create_model(klass, attributes)
-      klass.create!(attributes)
+      klass.unscoped { klass.create!(attributes) }
     end
   end
 end


### PR DESCRIPTION
I use paranoia in one of my apps, which means I can't use the standard ActiveRecord adapter very easily.

I'd like to suggest all finds within the ActiveRecord adapter should be unscoped to avoid default scopes.

For now I'm happy to monkey-patch pickle in my app, but thought this might be worth a discussion.
