### PR TITLE
Index records with a canonical name

### DIFF
--- a/lib/pickle/session.rb
+++ b/lib/pickle/session.rb
@@ -204,7 +204,7 @@ module Pickle
     end
     
     def store_record(factory, name, record)
-      models_by_name(factory)[name] = record
+      models_by_name(factory)[pickle_parser.canonical(name)] = record
       models_by_index(factory) << record
     end
   end

--- a/spec/pickle/session_spec.rb
+++ b/spec/pickle/session_spec.rb
@@ -429,4 +429,17 @@ describe Pickle::Session do
   it "#created_model!('unknown') should raise informative error message" do
     lambda { created_model!('unknown') }.should raise_error(Pickle::Session::ModelNotKnownError)
   end
+
+  describe "#store_record" do
+    let(:factory) { "user" }
+    let(:name) { "the admin" }
+    let(:record) { "User class" }
+
+    it "should index by canonical name" do
+      should_receive(:models_by_name).with(factory).and_return({})
+      should_receive(:models_by_index).with(factory).and_return([])
+      Pickle::Parser.any_instance.should_receive(:canonical).with(name)
+      store_record(factory, name, record)
+    end
+  end
 end


### PR DESCRIPTION
When storing a record with a non canonical name (for example "The User") created_model will use the canonical name for fetching (due to parse_model) and raise a ModelNotKnownError.

I've changed store_record to index every record with its name in the canonical form.
I've also added a spec that ensures that the canonical method is called with the name upon indexing through store_record.

Steps to reproduce:

``` ruby
store_record('user','The User','User class') # @models_by_name == { "user" => {"The User" => "User class" }}
created_model("user \"The User\"") # parse_model returns ["user", "the_user"] and raises ModelNotKnownError
```

Cheers
