### PR TITLE
Fix deprecated finder methods (Rails 4)

### DIFF
--- a/lib/pickle/adapters/active_record.rb
+++ b/lib/pickle/adapters/active_record.rb
@@ -41,14 +41,14 @@ class ActiveRecord::Base
 
     # Find the first instance matching conditions
     def self.find_first_model(klass, conditions)
-      klass.find(:first, :conditions => conditions)
+      klass.where(conditions).first
     end
 
     # Find all models matching conditions
     def self.find_all_models(klass, conditions)
-      klass.find(:all, :conditions => conditions)
+      klass.where(conditions)
     end
-    
+
     # Create a model using attributes
     def self.create_model(klass, attributes)
       klass.create!(attributes)


### PR DESCRIPTION
Use the new finder syntax to remove deprecation warning when used with Rails 4 (4.0.0)

`DEPRECATION WARNING: Calling #find(:first) is deprecated. Please call #first directly instead. You have also used finder options. These are also deprecated. Please build a scope instead of using finder options.`
