### PR TITLE
Better email validation messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # system crap
 .DS_Store
+.idea
 
 # local ruby/gems dev stuff
 .rvmrc

--- a/rails_generators/pickle/templates/email_steps.rb
+++ b/rails_generators/pickle/templates/email_steps.rb
@@ -27,37 +27,39 @@ When(/^(?:I|they) click the first link in #{capture_email}$/) do |email_ref|
 end
 
 Then(/^(\d)+ emails? should be delivered to (.*)$/) do |count, to|
-  expect(emails("to: \"#{email_for(to)}\"").size).to eq(count.to_i)
+  actual = emails("to: \"#{email_for(to)}\"").size
+  expect(actual).to eq(count.to_i), "Expected #{count} emails but encountered #{actual} delivered to #{to}"
 end
 
 Then(/^(\d)+ emails? should be delivered with #{capture_fields}$/) do |count, fields|
-  expect(emails(fields).size).to eq(count.to_i)
+  actual = emails(fields).size
+  expect(actual).to eq(count.to_i), "Expected #{count} emails but encountered #{actual} to be delivered with #{fields}"
 end
 
 Then(/^#{capture_email} should be delivered to (.+)$/) do |email_ref, to|
-  expect(email(email_ref, "to: \"#{email_for(to)}\"")).not_to be_nil
+  expect(email(email_ref, "to: \"#{email_for(to)}\"")).not_to be_nil, "Failed to find #{email_ref} delivered to: #{to}"
 end
 
 Then(/^#{capture_email} should not be delivered to (.+)$/) do |email_ref, to|
-  expect(email(email_ref, "to: \"#{email_for(to)}\"")).to be_nil
+  expect(email(email_ref, "to: \"#{email_for(to)}\"")).to be_nil, "Unexpectedly found #{email_ref} delivered to: #{to}"
 end
 
 Then(/^#{capture_email} should have #{capture_fields}$/) do |email_ref, fields|
-  expect(email(email_ref, fields)).not_to be_nil
+  expect(email(email_ref, fields)).not_to be_nil, "Failed to find #{fields} in #{email_ref}"
 end
 
 Then(/^#{capture_email} should contain "(.*)"$/) do |email_ref, text|
-  expect(email(email_ref).body).to match(/#{text}/)
+  expect(email(email_ref).body).to match(/#{text}/), "Failed to find \"#{text}\" in #{email_ref}"
 end
 
 Then(/^#{capture_email} should not contain "(.*)"$/) do |email_ref, text|
-  expect(email(email_ref).body).not_to match(/#{text}/)
+  expect(email(email_ref).body).not_to match(/#{text}/), "Unexpectedly found \"#{text}\" in #{email_ref}"
 end
 
 Then(/^#{capture_email} should link to (.+)$/) do |email_ref, page|
-  expect(email(email_ref).body).to match(/#{path_to(page)}/)
+  expect(email(email_ref).body).to match(/#{path_to(page)}/), "Failed to find link to #{page} in #{email_ref}"
 end
 
 Then(/^show me the emails?$/) do
-   save_and_open_emails
+  save_and_open_emails
 end


### PR DESCRIPTION
The validation messages in email_steps can be really misleading i.e. comparing against nil, when trying to find an email with a subject.  This can lead you down the wrong path such as trying to figure out why there isn't an email,  when there simply isn't an email matching that subject. We've had a few of these popup over time so I figured I'd solve this once and for all.

I've put rspec customized messages that should yield better context for assertion failures.
