### PR TITLE
update for fabrication adapter with protected method klass

### DIFF
--- a/lib/pickle/adapter.rb
+++ b/lib/pickle/adapter.rb
@@ -153,7 +153,7 @@ module Pickle
 
       def initialize(factory)
         if defined? ::Fabrication
-          @klass, @name = factory[1].klass, factory[0].to_s
+          @klass, @name = factory[1].send(:klass), factory[0].to_s
         end
       end
 


### PR DESCRIPTION
Since Fabrication's release of [v2.13](https://github.com/paulelliott/fabrication/releases/tag/2.13.0), the pickle adapter to it has been broken due to the method klass being made protected. As Fabrication is steadily improving, I now want to sue the new version.

This is a small pull request to use `.send(:klass)` instead of '.klass' to access the protected method, and everything works again.
