### PR TITLE
Build proper path for models within modules

### DIFF
--- a/Rakefile.d/cucumber.rake
+++ b/Rakefile.d/cucumber.rake
@@ -16,7 +16,7 @@ namespace :cucumber do
     Bundler.with_clean_env do
       gemfile = "cucumber_test_app/Gemfile"
       rm_rf "cucumber_test_app"
-      sh "rails new cucumber_test_app --skip-javascript --skip-sprockets"
+      sh "bundle exec rails new cucumber_test_app --skip-javascript --skip-sprockets"
       sh "echo 'gem \"cucumber-rails\", :require => false' >> #{gemfile}"
       sh "echo 'gem \"rspec-rails\", \"~>3.0\"' >> #{gemfile}"
       sh "echo 'gem \"capybara\"' >> #{gemfile}"

--- a/lib/pickle/path.rb
+++ b/lib/pickle/path.rb
@@ -36,7 +36,7 @@ module Pickle
     def pickle_path_for_resources_action_segment(resources, action, segment)
       action.blank? or action = action.downcase.gsub(' ','_')
       segment.blank? or segment = segment.downcase.gsub(' ','_')
-      resource_names = resources.map{|s| s.is_a?(Symbol) ? s.to_s : s.class.name.underscore}.join("_")
+      resource_names = resources.map{|s| s.is_a?(Symbol) ? s.to_s : s.class.name.underscore.gsub('/', '_')}.join("_")
       models = resources.reject{|s| s.is_a?(Symbol)}
       parts = [action, resource_names, segment].reject(&:blank?)
       send("#{parts.join('_')}_path", *models) rescue nil

--- a/spec/pickle/path_spec.rb
+++ b/spec/pickle/path_spec.rb
@@ -4,7 +4,7 @@ require 'pickle/path'
 
 describe Pickle::Path do
   include Pickle::Path
-  
+
   describe "#path_to_pickle, when the model doesn't exist" do
     before do
       allow(self).to receive(:model).and_return(nil)
@@ -12,81 +12,81 @@ describe Pickle::Path do
     it "('that user', :extra => 'new comment') should raise the error raised by model!" do
       expect { path_to_pickle "that user", "new comment" }.to raise_error(RuntimeError, 'Could not figure out a path for ["that user", "new comment"] {}')
     end
-    
+
   end
-  
+
   describe "#path_to_pickle" do
     describe "when model returns a user" do
       let :user_class do
         double 'User', :name => 'User'
       end
-      
+
       let :user do
         double 'user', :class => user_class
       end
-      
+
       before do
         allow(self).to receive(:model).and_return(user)
       end
-    
+
       it "('a user', 'the user: \"fred\"') should retrieve 'a user', and 'the user: \"fred\"' models" do
         expect(self).to receive(:model).with('a user')
         expect(self).to receive(:model).with('the user: "fred"')
         allow(self).to receive(:user_user_path).and_return('the path')
         expect(path_to_pickle('a user', 'the user: "fred"')).to eq('the path')
       end
-    
+
       it "('a user', :action => 'foo') should return foo_user_path(<user>)" do
         expect(self).to receive(:foo_user_path).with(user).and_return('the path')
         expect(path_to_pickle('a user', :action => 'foo')).to eq('the path')
       end
-    
+
       it "('a user', :action => 'foo') should raise informative error if foo_user_path not defined" do
         expect(self).to receive(:foo_user_path).with(user).and_raise(NoMethodError)
         expect { path_to_pickle('a user', :action => 'foo') }.to raise_error(Exception, /Could not figure out a path for/)
       end
-    
+
       it "('a user', :segment => 'foo') should return user_foo_path(<user>)" do
         expect(self).to receive(:user_foo_path).with(user).and_return('the path')
         expect(path_to_pickle('a user', :segment => 'foo')).to eq('the path')
       end
-    
+
       it "('a user', :segment => 'foo') should raise informative error if foo_user_path not defined" do
         expect(self).to receive(:user_foo_path).with(user).and_raise(NoMethodError)
         expect { path_to_pickle('a user', :segment => 'foo') }.to raise_error(Exception, /Could not figure out a path for/)
       end
-    
+
       it "('a user', :action => 'new', :segment => 'comment') should return new_user_comment_path(<user>)" do
         expect(self).to receive(:new_user_comment_path).with(user).and_return('the path')
         expect(path_to_pickle('a user', :segment => 'comment', :action => 'new')).to eq('the path')
       end
-    
+
       it "('a user', :action => 'new', :segment => 'comment') should raise informative error if new_user_comment_path not defined" do
         expect(self).to receive(:new_user_comment_path).with(user).and_raise(NoMethodError)
         expect { path_to_pickle('a user', :action => 'new', :segment => 'comment') }.to raise_error(Exception, /Could not figure out a path for/)
       end
-    
+
       it "('a user', :extra => 'new comment') should return new_user_comment_path(<user>)" do
         expect(self).to receive(:new_user_comment_path).with(user).and_return('the path')
         expect(path_to_pickle('a user', :extra => 'new comment')).to eq('the path')
       end
-    
+
       it "('a user', :extra => 'new comment') should raise informative error if new_user_comment_path not defined" do
         expect(self).to receive(:new_user_comment_path).with(user).and_raise(NoMethodError)
         expect { path_to_pickle('a user', :extra => 'new comment') }.to raise_error(Exception, /Could not figure out a path for/)
       end
-      
+
       describe "when args is a list of pickle and non pickle models" do
         before do
           allow(self).to receive(:model).with("account").and_return(nil)
         end
-      
+
         it "('account', 'the user') should return account_user_path(<user>)" do
           expect(self).to receive(:account_user_path).with(user).and_return("the path")
           expect(path_to_pickle('account', 'the user')).to eq('the path')
         end
       end
-      
+
       describe "(private API)" do
         it "('a user', :extra => 'new ish comment') should try combinations of 'new', 'ish', 'comment'" do
           expect(self).to receive(:pickle_path_for_resources_action_segment).with([user], '', 'new_ish_comment').once
@@ -95,6 +95,25 @@ describe Pickle::Path do
           expect(self).to receive(:pickle_path_for_resources_action_segment).with([user], 'new_ish_comment', '').once
           expect { path_to_pickle('a user', :extra => 'new ish comment') }.to raise_error(Exception, /Could not figure out a path for/)
         end
+      end
+    end
+
+    describe "when model returns namespaced user" do
+      let :user_class do
+        double 'User', :name => 'Admin::User'
+      end
+
+      let :user do
+        double 'user', :class => user_class
+      end
+
+      before do
+        allow(self).to receive(:model).and_return(user)
+      end
+
+      it "('a user', :action => 'foo') should return foo_admin_user_path(<user>)" do
+        expect(self).to receive(:foo_admin_user_path).with(user).and_return('the path')
+        expect(path_to_pickle('a user', :action => 'foo')).to eq('the path')
       end
     end
   end


### PR DESCRIPTION
Given I have a model witing module

``` ruby
module Admin
  class User < ActiveRecord::Base
  end
end
```

I try to use it as "I am on userl's page"
But it generates wrong path method name: 'admin/user_path' and the step fails.
