### PR TITLE
replace alias_method_chain by Module#prepend

### DIFF
--- a/lib/pickle/session/parser.rb
+++ b/lib/pickle/session/parser.rb
@@ -2,22 +2,24 @@ module Pickle
   module Session
     # add ability to parse model names as fields, using a session
     module Parser
+      module ParseFieldWithModel
+        def parse_field(field)
+          if session && field =~ /^(\w+): #{capture_model}$/
+            {$1 => session.model!($2)}
+          else
+            super(field)
+          end
+        end
+      end
+
       def self.included(parser_class)
-        parser_class.alias_method_chain :parse_field, :model
+        parser_class.prepend ParseFieldWithModel
       end
 
       attr_accessor :session
 
       def match_field
         "(?:\\w+: (?:#{match_model}|#{match_value}))"
-      end
-
-      def parse_field_with_model(field)
-        if session && field =~ /^(\w+): #{capture_model}$/
-          {$1 => session.model!($2)}
-        else
-          parse_field_without_model(field)
-        end
       end
 
       def parse_hash(hash)

--- a/lib/pickle/session/parser.rb
+++ b/lib/pickle/session/parser.rb
@@ -13,7 +13,7 @@ module Pickle
       end
 
       def self.included(parser_class)
-        parser_class.prepend ParseFieldWithModel
+        parser_class.send(:prepend,  ParseFieldWithModel)
       end
 
       attr_accessor :session


### PR DESCRIPTION
this eliminates the annoying deprecation warning on rails 5
and everything works fine 

it requires ruby 2.1 though I would just bump the requirement to be 2.2.2 like rails 5
