### PR TITLE
Fixes a bug that would try to look up the machinist sham name for

### DIFF
--- a/lib/pickle/adapters/mongoid.rb
+++ b/lib/pickle/adapters/mongoid.rb
@@ -13,7 +13,7 @@ module Mongoid
       # Gets a list of the available models for this adapter
       def self.model_classes
         ObjectSpace.each_object(Class).to_a.select do |klass|
-          klass.name && klass.ancestors.include?(Mongoid::Document)
+          klass.ancestors.include?(Mongoid::Document) && klass.name
         end
       end
 


### PR DESCRIPTION
non-model objects, resulting in the error "No sham defined for name (RuntimeError)"

replaces #62 
