### PR TITLE
Draft to fix warnings: raise an error when called with an Array

### DIFF
--- a/lib/pickle/parser.rb
+++ b/lib/pickle/parser.rb
@@ -25,6 +25,8 @@ module Pickle
 
     # given a string like 'foo: expr' returns {key => value}
     def parse_field(field)
+      raise ArgumentError, "Can't call parse_field on an Array" if field.is_a?(Array)
+
       if field =~ /^#{capture_key_and_value_in_field}$/
         { $1 => eval($2) }
       else


### PR DESCRIPTION
ruby 2.7 has a deprecation warning when Object#=~ is called on a array
saying its now always returning nil.

pickle should raise an error instead.

any comments on this ? 